### PR TITLE
Added: Action to add PRs to Github projects

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @roclub/platform-engineering
+* @manueleckarth @holgerson97

--- a/.github/workflows/projects_add_pr_to_projects.yaml
+++ b/.github/workflows/projects_add_pr_to_projects.yaml
@@ -1,0 +1,14 @@
+name: Add PR to Project
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to project
+        uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: 'https://github.com/orgs/roclub/projects/9'
+          github-token: ${{ secrets.PROJECTS_ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
- Added action yaml to add all opened PRs to platform engineering projects. Will be used in organizational ruleset.
- Updated CODEOWNERS to contain github CI/CD owners Nils & me