### PR TITLE
fix: Changed pr_title_checker.yml due to filepath error

### DIFF
--- a/.github/workflows/pr_title_checker.yml
+++ b/.github/workflows/pr_title_checker.yml
@@ -25,8 +25,8 @@ jobs:
           # locally clones remote repo to runner
           git clone https://${{ secrets.PULL_FROM_OTHER_REPOSITORIES }}@github.com/roclub/workflow-templates.git source-repo
           cd source-repo
-          # Specify the files you want to pull
-          cp -u .github/configs/pr-title-checker-config.json ../
+          # Specify the files you want to pull and copy them to a file folder to maintain the original structure
+          cp -u .github/configs/pr-title-checker-config.json ../../.github/configs/
     
       - name: Check PR title
         uses: thehanimo/pr-title-checker@v1.4.1


### PR DESCRIPTION
The former workflow file produced this error:

Error: Couldn't retrieve or parse the config file specified - Error: ENOENT: no such file or directory, open '/home/runner/work/miscellaneous-testing/miscellaneous-testing/.github/configs/pr-title-checker-config.json'

This is due to the step "pull file" copying the json config file to the root directory, but the step "Check PR title" expects it to be at .github/configs/pr-title-checker-config.json

The change in this PR changes the pull file step to save the config file in github/configs/pr-title-checker-config.json