### PR TITLE
feat: import secrets from vault

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -55,6 +55,19 @@ jobs:
           unzip awscliv2.zip
           sudo ./aws/install --update
 
+      - name: Import Secrets from Vault
+        id: secrets
+        uses: hashicorp/vault-action@v2
+        with:
+          url: https://vault.mgt.roclub.io
+          token: ${{ secrets.VAULT_TOKEN }}
+          secrets: |
+            ${{ secrets.ENV }}-aws/deploy accessKey | AWS_ACCESS_KEY_ID ;
+            ${{ secrets.ENV }}-aws/deploy secretKey | AWS_SECRET_ACCESS_KEY ;
+            github/terraform apiKey | TERRAFORM_CLOUD_AUTH ;
+            github/tailscale authKey | TAILSCALE_AUTH_KEY ;
+
+
       - name: "Install Terraform"
         uses: hashicorp/setup-terraform@v2
         with:
@@ -68,11 +81,11 @@ jobs:
 
       - name: "Validate Terraform"
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
           TF_VAR_ENVIRONMENT: ${{ inputs.terraform_workspace }}
-          TF_VAR_TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY }}
+          TF_VAR_TAILSCALE_AUTH_KEY: ${{ steps.secrets.outputs.TAILSCALE_AUTH_KEY }}
           TF_VAR_BUBBLE_CALLBACK_KEY: ${{ secrets.BUBBLE_CALLBACK_KEY }}
           TF_VAR_SYSDIG_SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_API_TOKEN }}
           TF_VAR_CONFLUENT_CLOUD_API_KEY: ${{ secrets.TF_VAR_CONFLUENT_CLOUD_API_KEY }}
@@ -87,11 +100,11 @@ jobs:
       - name: "Apply Terraform until target"
         if: ${{ inputs.target != '' }}
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
           TF_VAR_ENVIRONMENT: ${{ inputs.terraform_workspace }}
-          TF_VAR_TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY }}
+          TF_VAR_TAILSCALE_AUTH_KEY: ${{ steps.secrets.outputs.TAILSCALE_AUTH_KEY }}
           TF_VAR_BUBBLE_CALLBACK_KEY: ${{ secrets.BUBBLE_CALLBACK_KEY }}
           TF_VAR_SYSDIG_SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_API_TOKEN }}
           TF_VAR_CONFLUENT_CLOUD_API_KEY: ${{ secrets.TF_VAR_CONFLUENT_CLOUD_API_KEY }}
@@ -105,11 +118,11 @@ jobs:
       - name: "Apply Terraform until end"
         if: ${{ inputs.target == '' }}
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.AWS_DEFAULT_REGION }}
           TF_VAR_ENVIRONMENT: ${{ inputs.terraform_workspace }}
-          TF_VAR_TAILSCALE_AUTH_KEY: ${{ secrets.TAILSCALE_AUTH_KEY }}
+          TF_VAR_TAILSCALE_AUTH_KEY: ${{ steps.secrets.outputs.TAILSCALE_AUTH_KEY }}
           TF_VAR_BUBBLE_CALLBACK_KEY: ${{ secrets.BUBBLE_CALLBACK_KEY }}
           TF_VAR_SYSDIG_SECURE_API_TOKEN: ${{ secrets.SYSDIG_SECURE_API_TOKEN }}
           TF_VAR_CONFLUENT_CLOUD_API_KEY: ${{ secrets.TF_VAR_CONFLUENT_CLOUD_API_KEY }}


### PR DESCRIPTION
Import secrets from vault via workflow file

Currently supported keys: 

- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY 
- TERRAFORM_CLOUD_AUTH 
- TAILSCALE_AUTH_KEY 
