### PR TITLE
fix: golang code quality go version missmatch

### DIFF
--- a/.github/workflows/go_code_quality.yaml
+++ b/.github/workflows/go_code_quality.yaml
@@ -1,7 +1,8 @@
 name: Golang Code Quality
 
 env:
-  GO_VERSION: '1.21.3'
+  GO_VERSION: ${{ vars.GO_VERSION }}
+  GOLANGCI_LINT_VERSION: ${{ vars.GOLANGCI_LINT_VERSION }}
 
 on:
   push:
@@ -9,14 +10,13 @@ on:
       - '**.go'
       - 'go.mod'
   pull_request:
-    types: [opened, reopened]
 
 permissions:
-  contents: write
+  contents: read
+  pull-requests: read
 
 jobs:
-  code_qualitity:
-
+  code_quality:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -39,14 +39,14 @@ jobs:
             libgstreamer-plugins-base1.0-dev
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 #v5.0.2
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: false
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@c675eb70db3aa26b496bc4e64da320480338d41b # v3.0.0
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: "v1.58.1"
+          version: ${{ env.GOLANGCI_LINT_VERSION }} 
           install-mode: "goinstall"
           args: '--config=".github/linters/.golangci.yaml" --timeout 60m'


### PR DESCRIPTION
Fixed problem with incompatible go versions between setup go and golang lint action

Corresponding issue
https://github.com/roclub/platform-issues/issues/26

Tested here
https://github.com/roclub/controlplane/pull/175/commits/edd2d0bc30b109c9307505474c06a22a85164edc
 