### PR TITLE
fix: change golangci-lint install mode to binary

### DIFF
--- a/.github/workflows/go_code_quality.yaml
+++ b/.github/workflows/go_code_quality.yaml
@@ -51,5 +51,5 @@ jobs:
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }} 
-          install-mode: "goinstall"
+          install-mode: "binary"
           args: '--config=".github/linters/.golangci.yaml" --timeout 60m'


### PR DESCRIPTION
Closes #67 

Switches the install mode to the recommend binary mode.